### PR TITLE
support custom bucket name via CDN_HOST_BUCKET

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sync rails precompiled assets to S3 using aws-cli. Syncing is skipped if CDN_HOS
 
 ### Assumptions
 
-* S3 bucket is eponymously named after the CDN_HOST config variable. e.g. if `CDN_HOST=cdn.acme.net` then sync target is `s3://cdn.acme.net/`
+* S3 bucket is eponymously named after the `CDN_HOST` config variable. e.g. if `CDN_HOST=cdn.acme.net` then sync target is `s3://cdn.acme.net/` by default. If a custom bucket name is required, provide the `CDN_HOST_BUCKET` config variable.
 * assets have been compiled under `public/assets` -- ensure this buildpack runs after the ruby buildpack.
 
 ## Setup Instructions
@@ -39,6 +39,9 @@ Sync rails precompiled assets to S3 using aws-cli. Syncing is skipped if CDN_HOS
    heroku config:set AWS_ACCESS_KEY_ID=your_access_key
    heroku config:set AWS_SECRET_ACCESS_KEY=your_secret_key
    heroku config:set AWS_DEFAULT_REGION=us-east-1
+
+   # set CDN_HOST_BUCKET if bucket name is different than CDN_HOST
+   # heroku config:set CDN_HOST_BUCKET=your-s3-bucket-name
    ```
 
 ## Usage Example

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ requireVar(){
   if [ -e "$ENV_DIR/$var" ]; then
     value=$(cat "$ENV_DIR/$var")
   elif [ -n "$default" ]; then
-    echo "WARN: $var is not set, using default value: $default" >&2
+    echo "$var is not set, using default value: $default" >&2
     value="$default"
   fi
 
@@ -27,17 +27,16 @@ requireVar(){
 }
 
 requireVar CDN_HOST || {
-  echo "skipping asset sync" >&2
+  echo "skipping asset sync"
   exit 0
 }
-
 requireVar AWS_ACCESS_KEY_ID || exit 1
 requireVar AWS_SECRET_ACCESS_KEY || exit 1
 requireVar AWS_DEFAULT_REGION "us-east-1" || exit 1
+requireVar CDN_HOST_BUCKET "$CDN_HOST"
 
-bucket_name="$CDN_HOST"
-echo "syncing assets to $bucket_name"
-if ! aws s3 sync "$BUILD_DIR/public" "s3://$bucket_name" --progress; then
+echo "syncing assets to $CDN_HOST_BUCKET"
+if ! aws s3 sync "$BUILD_DIR/public" "s3://$CDN_HOST_BUCKET" --progress; then
   echo "ERROR: Failed to sync assets to S3" >&2
   exit 1
 fi


### PR DESCRIPTION
introduce CDN_HOST_BUCKET config variable to allow the bucket name to diverge from the value of CDN_HOST.