### PR TITLE
use s3sync instead of awscli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # heroku-buildpack-rails-assets-sync
 
-Sync rails precompiled assets to S3 using aws-cli. Syncing is skipped if CDN_HOST is not set or empty.
+Sync rails precompiled assets to S3 using [s3sync-rust](https://github.com/nidor1998/s3sync). Syncing is skipped if CDN_HOST is not set or empty.
 
 ## Requirements
 
-* [aws-cli](https://aws.amazon.com/cli/) (`aws` command) is available. provided by [heroku-buildpack-awscli](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-awscli)
 * AWS credentials (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY) are set as config variables and have appropriate credentials for writing the the S3 bucket.
 * the CDN_HOST config variable is used as  Rails.application.config.asset_host, e.g.
 
@@ -20,19 +19,13 @@ Sync rails precompiled assets to S3 using aws-cli. Syncing is skipped if CDN_HOS
 
 ## Setup Instructions
 
-1. Add the AWS CLI buildpack first:
-
-   ```sh
-   heroku buildpacks:add heroku-community/awscli
-   ```
-
-2. Add this buildpack _after_ the Ruby and AWS CLI buildpacks:
+1. Add this buildpack _after_ the ruby buildpack:
 
    ```sh
    heroku buildpacks:add https://github.com/starburstlabs/heroku-buildpack-rails-assets-sync
    ```
 
-3. Set required environment variables:
+2. Set required environment variables:
 
    ```sh
    heroku config:set CDN_HOST=cdn.yourdomain.com

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,7 @@
 # usage: bin/compile BUILD_DIR CACHE_DIR ENV_DIR
 
 BUILD_DIR="$1"
+CACHE_DIR="$2"
 ENV_DIR="$3"
 
 requireVar(){
@@ -33,9 +34,19 @@ requireVar AWS_ACCESS_KEY_ID || exit 1
 requireVar AWS_SECRET_ACCESS_KEY || exit 1
 requireVar AWS_DEFAULT_REGION "us-east-1" || exit 1
 requireVar CDN_HOST_BUCKET "$CDN_HOST"
+requireVar S3SYNC_URL "https://github.com/nidor1998/s3sync/releases/download/v1.13.4/s3sync-linux-glibc2.28-x86_64.tar.gz"
+
+[ -d "$CACHE_DIR" ] || mkdir -p "$CACHE_DIR"
+if [ -x "$CACHE_DIR/s3sync" ]; then
+  echo "using s3sync from cache" >&2
+else
+  echo "downloading s3sync from $S3SYNC_URL" >&2
+  curl -L "$S3SYNC_URL" | tar -xz -C "$CACHE_DIR"
+  chmod +x "$CACHE_DIR/s3sync"
+fi
 
 echo "syncing assets to $CDN_HOST_BUCKET"
-if ! /app/.awscli/bin/aws s3 sync "$BUILD_DIR/public/assets" "s3://$CDN_HOST_BUCKET/assets" --size-only; then
+if ! "$CACHE_DIR/s3sync" --remove-modified-filter "$BUILD_DIR/public/assets" "s3://$CDN_HOST_BUCKET/assets/"; then
   echo "ERROR: Failed to sync assets to S3" >&2
   exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -3,11 +3,6 @@
 
 BUILD_DIR="$1"
 
-/app/.awscli/bin/aws --version &>/dev/null || {
-  echo "ERROR: aws-cli is not installed. please add heroku-buildpack-awscli" >&2
-  exit 1
-}
-
 [ -d "$BUILD_DIR/public/assets" ] || {
   echo "ERROR: public/assets directory not found, have assets been compiled?" >&2
   exit 1


### PR DESCRIPTION
* replaces awscli with [s3sync-rust](https://github.com/nidor1998/s3sync)  for syncing assets. this reduces slug size as awscli is no longer preserved in the build.
* keeps a copy of s3sync in the cache for speedier builds.